### PR TITLE
Lower requested WASM memory for iOS user agents

### DIFF
--- a/js/web/web-backend.js
+++ b/js/web/web-backend.js
@@ -18,7 +18,9 @@ let init = wasm.default;
 let worker;
 
 async function initSnarkyJS() {
-  let { memory } = await init();
+  const memory = allocateWasmMemoryForUserAgent(window.navigator.userAgent);
+
+  await init(undefined, memory);
   let module = init.__wbindgen_wasm_module;
   let numWorkers = await getEfficientNumWorkers();
 
@@ -161,4 +163,22 @@ async function workerCall(worker, type, message) {
   let promise = waitForMessage(worker, id);
   worker.postMessage({ type, id, message });
   return (await promise).result;
+}
+
+function allocateWasmMemoryForUserAgent(userAgent) {
+  const isIOSDevice = /iPad|iPhone|iPod/.test(userAgent);
+  const isSafari = /Safari/.test(userAgent);
+  if (isIOSDevice && isSafari) {
+    return new WebAssembly.Memory({
+      initial: 19,
+      maximum: 16384, // 1 GiB
+      shared: true,
+    });
+  } else {
+    return new WebAssembly.Memory({
+      initial: 19,
+      maximum: 65536, // 4 GiB
+      shared: true,
+    });
+  }
 }

--- a/js/web/web-backend.js
+++ b/js/web/web-backend.js
@@ -19,8 +19,8 @@ let worker;
 
 async function initSnarkyJS() {
   const memory = allocateWasmMemoryForUserAgent(window.navigator.userAgent);
-
   await init(undefined, memory);
+
   let module = init.__wbindgen_wasm_module;
   let numWorkers = await getEfficientNumWorkers();
 
@@ -167,8 +167,7 @@ async function workerCall(worker, type, message) {
 
 function allocateWasmMemoryForUserAgent(userAgent) {
   const isIOSDevice = /iPad|iPhone|iPod/.test(userAgent);
-  const isSafari = /Safari/.test(userAgent);
-  if (isIOSDevice && isSafari) {
+  if (isIOSDevice) {
     return new WebAssembly.Memory({
       initial: 19,
       maximum: 16384, // 1 GiB


### PR DESCRIPTION
# Description
:link: Related Issue: https://github.com/o1-labs/snarkyjs/issues/823

This pull request addresses an issue where SnarkyJS applications encounter an `Out of Memory` error on iOS devices, specifically iPhones and iPads, while trying to initialize the WASM memory for plonk_wasm.js. This problem seems to be unique to iOS devices as desktop Safari doesn't appear to be affected.

The solution involves modifying the maximum requested WASM memory for iOS user agents. Through testing, it's been found that these devices can handle up to 1GiB of requested memory. Attempting to request 2GB results in the same memory error. However, for all other user agents, the memory request remains unchanged, aiming for the maximum available, which is 4GiB.