### PR TITLE
Prepend /bin/sh when running dump-test-vectors.sh

### DIFF
--- a/crypto/test_vectors/dump-test-vectors.sh
+++ b/crypto/test_vectors/dump-test-vectors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/crypto/test_vectors/dune
+++ b/crypto/test_vectors/dune
@@ -11,4 +11,4 @@
  (action
   (progn
    (run chmod -R +w ../../../../../crypto/proof-systems/ .)
-   (run /bin/sh %{script} poseidonKimchi.ts poseidonLegacy.ts))))
+   (run %{script} poseidonKimchi.ts poseidonLegacy.ts))))

--- a/crypto/test_vectors/dune
+++ b/crypto/test_vectors/dune
@@ -11,4 +11,4 @@
  (action
   (progn
    (run chmod -R +w ../../../../../crypto/proof-systems/ .)
-   (run %{script} poseidonKimchi.ts poseidonLegacy.ts))))
+   (run /bin/sh %{script} poseidonKimchi.ts poseidonLegacy.ts))))


### PR DESCRIPTION
While this should be redundant, it is not in my experience. Though I had the execution permission set, my system did not want to execute this script. It is not clear to me why, since the error would only say "file not found", hence I opted for this simple workaround.