### PR TITLE
Clean up SnarkyJS-OCaml, part 3

### DIFF
--- a/js/snarky-class-spec.js
+++ b/js/snarky-class-spec.js
@@ -65,10 +65,6 @@ export default [
         name: 'transactionCommitments',
         type: 'function',
       },
-      {
-        name: 'checkAccountUpdateSignature',
-        type: 'function',
-      },
     ],
   },
   {

--- a/js/snarky-class-spec.js
+++ b/js/snarky-class-spec.js
@@ -57,10 +57,6 @@ export default [
         name: 'customTokenIdChecked',
         type: 'function',
       },
-      {
-        name: 'createTokenAccount',
-        type: 'function',
-      },
     ],
   },
   {

--- a/js/snarky-class-spec.js
+++ b/js/snarky-class-spec.js
@@ -61,10 +61,6 @@ export default [
         name: 'createTokenAccount',
         type: 'function',
       },
-      {
-        name: 'transactionCommitments',
-        type: 'function',
-      },
     ],
   },
   {

--- a/mina-transaction/types.ts
+++ b/mina-transaction/types.ts
@@ -1,2 +1,3 @@
 export { provableFromLayout, toJSONEssential } from './gen/transaction.js';
 export * as Types from './gen/transaction.js';
+export * as TypesBigint from './gen/transaction-bigint.js';


### PR DESCRIPTION
- expose bigint transaction types
- remove unused check signature helper
- move helper for tx commitments
- some cleanup, remove unused method
