### PR TITLE
Add `structProvable`

### DIFF
--- a/lib/generic.ts
+++ b/lib/generic.ts
@@ -39,7 +39,7 @@ function structProvable<T extends {}, TValue extends {[K in keyof T]: any}, Fiel
   (typ: StructProvable<T, TValue, Field>):
       GenericProvable<
         {[K in keyof T]: T[K]},
-        {[K in keyof TValue]: TValue[K]},
+        {[K in keyof T]: TValue[K]},
         Field>
 {
     return {
@@ -90,8 +90,13 @@ function structProvable<T extends {}, TValue extends {[K in keyof T]: any}, Fiel
                 typ[field].check(x[field]);
             }
         },
-        toValue: (x) => { // Wtf?
-            throw new Error("TODO");
+        toValue: (x) => {
+            var res: {[K in keyof T]?: TValue[K]} = {};
+            var field: keyof T;
+            for (field in typ) {
+                res[field] = typ[field].toValue(x[field]);
+            }
+            return (res as {[K in keyof T]: TValue[K]});
         },
         fromValue: (x) => {
             var res: {[K in keyof T]?: T[K]} = {};


### PR DESCRIPTION
This PR introduces `structProvable`, an easy way to build a `GenericProvable` for an object with fields only.

Compiling example:
```typescript
type MyType<X, Y, Z> = {
    x: X,
    y: Y,
    z: Z,
}

type MyVarType<X, Y, Z> = {
    x: X,
    y: Y,
    z: Z,
}

function myTyp<X, XValue, Y, YValue, Z, ZValue, Field>(
    xtyp: GenericProvable<X, XValue, Field>,
    ytyp: GenericProvable<Y, YValue, Field>,
    ztyp: GenericProvable<Z, ZValue, Field>) {
    structProvable<MyVarType<X, Y, Z>, MyType<XValue, YValue, ZValue>, Field>({x: xtyp, y: ytyp, z: ztyp});
};

type MyRecord = {
    x: [],
    y: [],
    z: [],
}

type MyVarRecord = {
    x: [],
    y: [],
    z: [],
}

function EmptyListType(): GenericProvable<[], [], []> { throw new Error("TODO"); }

let myRecordTyp : GenericProvable<MyRecord, MyVarRecord, []> = structProvable({x: EmptyListType(), y: EmptyListType(), z: EmptyListType()});
```

Idealised example assuming supporting `GenericProvable`s for the fields:
```typescript
type MyVarStructure = {
    b: boolean,
    i: Int32,
}
type MyValueStructure = {
    b: Boolean,
    i: Int32,
}

let myStructureTyp : GenericProvable<MyVarStructure, MyValueStructure, Field> =
  structProvable({b: booleanTyp, i: int32Typ});
```